### PR TITLE
add test and benchmarks

### DIFF
--- a/01-go-level-1/fibonacci/fiblib/benchmark_test.go
+++ b/01-go-level-1/fibonacci/fiblib/benchmark_test.go
@@ -1,0 +1,40 @@
+package fiblib
+
+import "testing"
+
+var (
+	GlobalRes uint64
+	GlobalN   uint64 = 10
+)
+
+func BenchmarkFibonacciRecur(b *testing.B) {
+	var res uint64
+	for i := 0; i < b.N; i++ {
+		res = FibonacciRecur(GlobalN)
+	}
+	GlobalRes = res
+}
+
+func BenchmarkFibonacciGoldenRatio(b *testing.B) {
+	var res uint64
+	for i := 0; i < b.N; i++ {
+		res = FibonacciRecur(GlobalN)
+	}
+	GlobalRes = res
+}
+
+func BenchmarkFibonacciMapUse(b *testing.B) {
+	var res uint64
+	for i := 0; i < b.N; i++ {
+		res = FibonacciRecur(GlobalN)
+	}
+	GlobalRes = res
+}
+
+func BenchmarkFibonacciAnonymousFunc(b *testing.B) {
+	var res uint64
+	for i := 0; i < b.N; i++ {
+		res = FibonacciRecur(GlobalN)
+	}
+	GlobalRes = res
+}

--- a/01-go-level-1/fibonacci/fiblib/example_test.go
+++ b/01-go-level-1/fibonacci/fiblib/example_test.go
@@ -1,0 +1,8 @@
+package fiblib
+
+import "fmt"
+
+func ExampleFibonacciGoldenRatio() {
+	fmt.Printf("%d", FibonacciGoldenRatio(3))
+	// Output: 2
+}

--- a/01-go-level-1/fibonacci/fiblib/fib_test.go
+++ b/01-go-level-1/fibonacci/fiblib/fib_test.go
@@ -1,0 +1,13 @@
+package fiblib
+
+import "testing"
+
+var vf = []uint64{0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181, 6765}
+
+func TestFibonacciMapUse(t *testing.T) {
+	for i := 0; i < len(vf); i++ {
+		if f := FibonacciMapUse(uint64(i)); f != vf[i] {
+			t.Logf("Fibonacci %d = %d, want - %d", i, f, vf[i])
+		}
+	}
+}

--- a/01-go-level-1/fibonacci/fiblib/fiblib.go
+++ b/01-go-level-1/fibonacci/fiblib/fiblib.go
@@ -1,13 +1,11 @@
 package fiblib
 
 import (
-	"fmt"
 	"math"
 )
 
 // FibonacciMapUse descr (bif o: O(n))
 func FibonacciMapUse(n uint64) uint64 {
-	fmt.Print("--== Fibonacci map using ==--")
 	fibMap := make(map[uint64]uint64)
 	var num, i uint64
 	for ; i <= n; i++ {
@@ -26,7 +24,6 @@ func FibonacciMapUse(n uint64) uint64 {
 
 // FibonacciAnonymousFunc descr (bif o: O(n))
 func FibonacciAnonymousFunc() func() uint64 {
-	fmt.Print("--== Fibonacci anonymous func using ==--")
 	var n1, n2 uint64 = 0, 1
 	return func() uint64 {
 		n1, n2 = n2, n1+n2
@@ -40,7 +37,6 @@ func FibonacciAnonymousFunc() func() uint64 {
 //      formula: n = (pow(phi,n) - pow((1 - phi), n)) / sqrt(5)
 func FibonacciGoldenRatio(n uint64) uint64 {
 	// const phi = 1.618033988749895
-	fmt.Println("--== Fibonacci golden ratio ==--")
 	if n < 0 {
 		return 0
 	}

--- a/01-go-level-1/fibonacci/fiblib/tables_test.go
+++ b/01-go-level-1/fibonacci/fiblib/tables_test.go
@@ -1,0 +1,24 @@
+package fiblib
+
+import "testing"
+
+func TestFibonacciGoldenRatio(t *testing.T) {
+	tests := []struct {
+		name string
+		in   uint64
+		want uint64
+	}{
+		{"simple", 3, 2},
+		{"negative", 0, 100},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := FibonacciGoldenRatio(tc.in)
+			if got != tc.want {
+				t.Fatalf("%s: expected %v; got - %v", tc.name, tc.want, got)
+			}
+		})
+	}
+}

--- a/01-go-level-1/fibonacci/fiblib/try_testify_test.go
+++ b/01-go-level-1/fibonacci/fiblib/try_testify_test.go
@@ -1,0 +1,15 @@
+package fiblib
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSmth(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	assert.Equal(uint64(2), FibonacciGoldenRatio(3), "they should be equal")
+	require.NotEqual(uint64(3), FibonacciGoldenRatio(3), "they should not be equal")
+
+}

--- a/01-go-level-1/src/algorithms/sorting/benchmark_test.go
+++ b/01-go-level-1/src/algorithms/sorting/benchmark_test.go
@@ -1,0 +1,36 @@
+package sorting
+
+import (
+	"algorithms/various"
+	"testing"
+)
+
+var (
+	GlobalRes    []int
+	sliceElemNum = 10
+)
+
+func BenchmarkInsertationSort(b *testing.B) {
+	var res []int
+	mySl := various.GenerSlice(sliceElemNum)
+	for i := 0; i < b.N; i++ {
+		res = InsertationSort(mySl)
+	}
+	GlobalRes = res
+}
+
+func BenchmarkBubleSort(b *testing.B) {
+	var res []int
+	mySl := various.GenerSlice(sliceElemNum)
+	for i := 0; i < b.N; i++ {
+		res = BubleSort(mySl)
+	}
+	GlobalRes = res
+}
+
+func BenchmarkQuickSort(b *testing.B) {
+	mySl := various.GenerSlice(sliceElemNum)
+	for i := 0; i < b.N; i++ {
+		QuickSort(mySl, 0, len(mySl)-1)
+	}
+}


### PR DESCRIPTION
1) Добавлены тесты и бенчмарки для Фибоначчи
2) Бенчмарки для разных реализаций сортировки. Из бенчмарков видно, насколько эффективнее алгоритм быстрой сортировки (по количеству операций):
BenchmarkInsertationSort-4      12012099                96.8 ns/op
BenchmarkBubleSort-4                 7925994                 140 ns/op
BenchmarkQuickSort-4                   357414               4218 ns/op

+ benchstat в формате csv:
benchstat -csv /tmp/quickSort.txt /tmp/insertSort.txt
name,old time/op (ns/op),±,new time/op (ns/op),±,delta,±
Sort-4,3.08500E+03,0%,1.42000E+02,0%,~,(p=1.000 n=1+1)